### PR TITLE
Development/in x acid

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ This table shows their mapping. The left side is the first base, the top is the 
 | [mvl](#mvl)  | Move one unit to the left | DONE! |
 | [cop](#cop)  | Turn on copy mode | DONE! |
 | [off](#off)  | Turn off copy mode | DONE! |
-| [ina](#ina)  | Insert A to the right of this unit | |
-| [inc](#inc)  | Insert C to the right of this unit | |
-| [ing](#ing)  | Insert G to the right of this unit | |
-| [int](#int)  | Insert T to the right of this unit | |
+| [ina](#ina)  | Insert A to the right of this unit | DONE!  |
+| [inc](#inc)  | Insert C to the right of this unit | DONE! |
+| [ing](#ing)  | Insert G to the right of this unit | DONE! |
+| [int](#int)  | Insert T to the right of this unit | DONE! |
 | [rpy](#rpy)  | Search of the nearest pyrimidine to the right | |
 | [rpu](#rpu)  | Search for the nearest purine to the right | |
 | [lpy](#lpy)  | Search for the nearest pyrimidine to the left | |

--- a/src/amino_acids.c
+++ b/src/amino_acids.c
@@ -175,6 +175,7 @@ void ina_acid(struct strand* strandPointer) {
  * 
 */
 void inc_acid(struct strand* strandPointer) {
+    insert_base_subInstruction(strandPointer, 'C'); 
 }
 /* ------ FUNCTION ------*/ 
 /*
@@ -188,6 +189,7 @@ void inc_acid(struct strand* strandPointer) {
  * 
 */
 void ing_acid(struct strand* strandPointer) {
+    insert_base_subInstruction(strandPointer, 'G'); 
 }
 /* ------ FUNCTION ------*/ 
 /*
@@ -201,6 +203,7 @@ void ing_acid(struct strand* strandPointer) {
  * 
 */
 void int_acid(struct strand* strandPointer) {
+    insert_base_subInstruction(strandPointer, 'T'); 
 }
 /* ------ FUNCTION ------*/ 
 /*

--- a/src/amino_acids.c
+++ b/src/amino_acids.c
@@ -1,118 +1,5 @@
 #include "strand_def.h"
-
-/* ------ FUNCTION ------*/ 
-/*
- * performs copy mode function to be called when a base needs to be copied  
- *
- * Accepts:  
- * strand struct pointer
- * Returns: 
- * nothing 
- *
- * 
-*/
-void copy_base_subInstruction(struct strand *strandPointer) {
-    if(strandPointer->boundStrandFlag == 0) {
-        switch(strandPointer->mainStrand[strandPointer->currentBoundPosition-1]) {
-            case 'A':
-                strandPointer->complementaryStrand[strandPointer->currentBoundPosition-1] = 'T';
-                break;
-            case 'T':
-                strandPointer->complementaryStrand[strandPointer->currentBoundPosition-1] = 'A';
-                break;
-            case 'G':
-                strandPointer->complementaryStrand[strandPointer->currentBoundPosition-1] = 'C';
-                break;
-            case 'C':
-                strandPointer->complementaryStrand[strandPointer->currentBoundPosition-1] = 'G';
-                break;
-        }
-        //if the current bound position is greater than the size of the strand being copied to, 
-        //set the size to be the current bound position
-        //size does not care about spaces, just the furthest element slot occupied.
-        if(strandPointer->currentBoundPosition > strandPointer->complementarySize) { 
-            strandPointer->complementarySize = strandPointer->currentBoundPosition; 
-        }
-    } else {
-        switch (strandPointer->complementaryStrand[strandPointer->currentBoundPosition-1]) {
-            case 'A':
-                strandPointer->mainStrand[strandPointer->currentBoundPosition-1] = 'T';
-                break;
-            case 'T':
-                strandPointer->mainStrand[strandPointer->currentBoundPosition-1] = 'A';
-                break;
-            case 'G':
-                strandPointer->mainStrand[strandPointer->currentBoundPosition-1] = 'C';
-                break;
-            case 'C':
-                strandPointer->mainStrand[strandPointer->currentBoundPosition-1] = 'G';
-                break;
-        }
-
-        //if the current bound position is greater than the size of the strand being copied to, 
-        //set the size to be the current bound position
-        //size does not care about spaces, just the furthest element slot occupied.
-        if(strandPointer->currentBoundPosition > strandPointer->mainSize) { 
-            strandPointer->mainSize = strandPointer->currentBoundPosition; 
-        }
-    }
-}
-
-/* ------ FUNCTION ------*/ 
-/*
- * Performs general action of moving the enzymes position, and copy mode functionailty
- * 
- * Sub instruction called as a part of move commands, like mvr/mvl or searches. Also handles copy functionality
- * 
- *   boundStrand |  moveDirection | increment or decrement
- *   ----------------------------------------------------
- *    0 (main)   |   0 (right)    |         +
- *    0 (main)   |   1 (left)     |         -
- *    1 (comp)   |   0 (right)    |         -
- *    1 (comp)   |   1 (left)     |         +
- *
- * Accepts:  
- * current enzyme position,
- * currently bound strand flag 
- * Returns: 
- * int of newly bound position 
- * 
-*/
-
-
-void  move_subInstruction(struct strand *strandPointer, int moveDirection) {
-
-    switch (strandPointer->boundStrandFlag) {
-        case 0:
-            switch (moveDirection) {
-                case 0:
-                    strandPointer->currentBoundPosition += 1; 
-                    break;
-                case 1:
-                    strandPointer->currentBoundPosition -= 1; 
-                    break; 
-            }
-            break;
-        case 1:
-            switch (moveDirection) {
-                case 0:
-                    strandPointer->currentBoundPosition -= 1; 
-                    break;
-                case 1:
-                    strandPointer->currentBoundPosition += 1; 
-                    break;
-            }
-            break;
-    }
-
-    switch (strandPointer->copyModeFlag) {
-        case 1:
-            copy_base_subInstruction(strandPointer);
-            break;
-        default:
-            break;
-            }
-    }
+#include "sub_instructions.c"
 
 /* ------ FUNCTION ------*/ 
 /*
@@ -246,11 +133,11 @@ void mvl_acid(struct strand *strandPointer) {
 */
 void cop_acid(struct strand *strandPointer) {
     strandPointer->copyModeFlag = 1;
-    copy_base_subInstruction(strandPointer); 
+    copy_base_subInstruction(strandPointer,strandPointer->currentBoundPosition-1); 
 }
 /* ------ FUNCTION ------*/ 
 /*
- * Performs cop amino acid functionality 
+ * Performs off amino acid functionality 
  * Strand turns off copy mode- sets a flag in the struct
  *
  * Accepts:  
@@ -261,6 +148,59 @@ void cop_acid(struct strand *strandPointer) {
 */
 void off_acid(struct strand *strandPointer) {
     strandPointer->copyModeFlag = 0;
+}
+/* ------ FUNCTION ------*/ 
+/*
+ * Performs ina amino acid functionality 
+ * inserts A to the right of the bound unit
+ *
+ * Accepts:  
+ * struct pointer of type strand 
+ * Returns: 
+ * nothing 
+ * 
+*/
+void ina_acid(struct strand* strandPointer) {
+    insert_base_subInstruction(strandPointer, 'A'); 
+}
+/* ------ FUNCTION ------*/ 
+/*
+ * Performs inc amino acid functionality 
+ * inserts C to the right of the bound unit
+ *
+ * Accepts:  
+ * struct pointer of type strand 
+ * Returns: 
+ * nothing 
+ * 
+*/
+void inc_acid(struct strand* strandPointer) {
+}
+/* ------ FUNCTION ------*/ 
+/*
+ * Performs ing amino acid functionality 
+ * inserts G to the right of the bound unit
+ *
+ * Accepts:  
+ * struct pointer of type strand 
+ * Returns: 
+ * nothing 
+ * 
+*/
+void ing_acid(struct strand* strandPointer) {
+}
+/* ------ FUNCTION ------*/ 
+/*
+ * Performs int amino acid functionality 
+ * inserts T to the right of the bound unit
+ *
+ * Accepts:  
+ * struct pointer of type strand 
+ * Returns: 
+ * nothing 
+ * 
+*/
+void int_acid(struct strand* strandPointer) {
 }
 /* ------ FUNCTION ------*/ 
 /*
@@ -297,12 +237,16 @@ void call_instruction(int instructionnumber, struct strand *userStrandPointer) {
             off_acid(userStrandPointer);
             break;
         case 8:
+            ina_acid(userStrandPointer);
             break;
         case 9:
+            inc_acid(userStrandPointer);
             break;
         case 10:
+            ing_acid(userStrandPointer);
             break;
         case 11:
+            int_acid(userStrandPointer);
             break;
         case 12:
             break;

--- a/src/sub_instructions.c
+++ b/src/sub_instructions.c
@@ -1,0 +1,177 @@
+#include "strand_def.h"
+
+/* ------ FUNCTION ------*/ 
+/*
+ * performs copy mode function to be called when a base needs to be copied  
+ *
+ * Accepts:  
+ * strand struct pointer
+ * Returns: 
+ * nothing 
+ *
+ * 
+*/
+void copy_base_subInstruction(struct strand *strandPointer, int insertIndex) {
+    if(strandPointer->boundStrandFlag == 0) {
+        switch(strandPointer->mainStrand[insertIndex]) {
+            case 'A':
+                strandPointer->complementaryStrand[insertIndex] = 'T';
+                break;
+            case 'T':
+                strandPointer->complementaryStrand[insertIndex] = 'A';
+                break;
+            case 'G':
+                strandPointer->complementaryStrand[insertIndex] = 'C';
+                break;
+            case 'C':
+                strandPointer->complementaryStrand[insertIndex] = 'G';
+                break;
+        }
+        //if the current bound position is greater than the size of the strand being copied to, 
+        //set the size to be the current bound position
+        //size does not care about spaces, just the furthest element slot occupied.
+        if(strandPointer->currentBoundPosition > strandPointer->complementarySize) { 
+            strandPointer->complementarySize = strandPointer->currentBoundPosition; 
+        }
+    } else {
+        switch (strandPointer->complementaryStrand[insertIndex]) {
+            case 'A':
+                strandPointer->mainStrand[insertIndex] = 'T';
+                break;
+            case 'T':
+                strandPointer->mainStrand[insertIndex] = 'A';
+                break;
+            case 'G':
+                strandPointer->mainStrand[insertIndex] = 'C';
+                break;
+            case 'C':
+                strandPointer->mainStrand[insertIndex] = 'G';
+                break;
+        }
+
+        //if the current bound position is greater than the size of the strand being copied to, 
+        //set the size to be the current bound position
+        //size does not care about spaces, just the furthest element slot occupied.
+        if(strandPointer->currentBoundPosition > strandPointer->mainSize) { 
+            strandPointer->mainSize = strandPointer->currentBoundPosition; 
+        }
+    }
+}
+
+/* ------ FUNCTION ------*/ 
+/*
+ * Performs general action of moving the enzymes position, and copy mode functionailty
+ * 
+ * Sub instruction called as a part of move commands, like mvr/mvl or searches. Also handles copy functionality
+ * 
+ *   boundStrand |  moveDirection | increment or decrement
+ *   ----------------------------------------------------
+ *    0 (main)   |   0 (right)    |         +
+ *    0 (main)   |   1 (left)     |         -
+ *    1 (comp)   |   0 (right)    |         -
+ *    1 (comp)   |   1 (left)     |         +
+ *
+ * Accepts:  
+ * current enzyme position,
+ * currently bound strand flag 
+ * Returns: 
+ * int of newly bound position 
+ * 
+*/
+
+
+void  move_subInstruction(struct strand *strandPointer, int moveDirection) {
+
+    switch (strandPointer->boundStrandFlag) {
+        case 0:
+            switch (moveDirection) {
+                case 0:
+                    strandPointer->currentBoundPosition += 1; 
+                    break;
+                case 1:
+                    strandPointer->currentBoundPosition -= 1; 
+                    break; 
+            }
+            break;
+        case 1:
+            switch (moveDirection) {
+                case 0:
+                    strandPointer->currentBoundPosition -= 1; 
+                    break;
+                case 1:
+                    strandPointer->currentBoundPosition += 1; 
+                    break;
+            }
+            break;
+    }
+
+    switch (strandPointer->copyModeFlag) {
+        case 1:
+            copy_base_subInstruction(strandPointer, strandPointer->currentBoundPosition-1);
+            break;
+        default:
+            break;
+            }
+    }
+
+/* ------ FUNCTION ------*/ 
+/*
+ * performs insert mode function to be called when a base needs to be inserted  
+ *
+ * Accepts:  
+ * strand struct pointer, char to be inserted 
+ * Returns: 
+ * nothing 
+ *
+ * 
+*/
+void insert_base_subInstruction(struct strand *strandPointer, char base) {
+   //if on the main strand  
+   if(strandPointer->boundStrandFlag == 0) {
+       for(int i = strandPointer->mainSize-1; i >= strandPointer->currentBoundPosition; i--) {
+           //move each element one space up
+           strandPointer->mainStrand[i+1] = strandPointer->mainStrand[i];
+       }
+       //set the element to the right of the bound position equal to the inserted base
+       strandPointer->mainStrand[strandPointer->currentBoundPosition] = base; 
+       //increase the size of the strand by 1 
+       strandPointer->mainSize += 1; 
+       //also insert a blank into the complementary strand
+       for(int i = strandPointer->complementarySize; i >= strandPointer->currentBoundPosition; i --) {
+           strandPointer->complementaryStrand[i] = strandPointer->complementaryStrand[i-1];
+       } 
+       if(strandPointer->copyModeFlag == 1) {
+           copy_base_subInstruction(strandPointer, strandPointer->currentBoundPosition); 
+       } else {
+           strandPointer->complementaryStrand[strandPointer->currentBoundPosition] = ' '; 
+       }
+       strandPointer->complementarySize += 1; 
+   //if on the complementary strand 
+   } else {
+       // THIS SHIT DONT WORK SO GOOD 
+       //
+       //
+       //
+       for(int i = strandPointer->complementarySize; i >= strandPointer->currentBoundPosition; i--) {
+           //shift everything up one 
+           strandPointer->complementaryStrand[i] = strandPointer->complementaryStrand[i-1];
+       }
+       strandPointer->complementaryStrand[strandPointer->currentBoundPosition-1] = base;
+       strandPointer->complementarySize +=1;
+       strandPointer->currentBoundPosition +=1;
+       //now insert 
+       for(int i = strandPointer->mainSize; i >= strandPointer->currentBoundPosition; i--) {
+           //move each element one space up
+           strandPointer->mainStrand[i+1] = strandPointer->mainStrand[i];
+       }
+/*
+       if(strandPointer->copyModeFlag == 1) {
+           copy_base_subInstruction(strandPointer, strandPointer->currentBoundPosition-3); 
+       } else {
+*/
+           strandPointer->mainStrand[strandPointer->currentBoundPosition-2] = ' '; 
+//       }
+       strandPointer->mainSize += 1; 
+   }
+
+}

--- a/src/sub_instructions.c
+++ b/src/sub_instructions.c
@@ -148,10 +148,6 @@ void insert_base_subInstruction(struct strand *strandPointer, char base) {
        strandPointer->complementarySize += 1; 
    //if on the complementary strand 
    } else {
-       // THIS SHIT DONT WORK SO GOOD 
-       //
-       //
-       //
        for(int i = strandPointer->complementarySize; i >= strandPointer->currentBoundPosition; i--) {
            //shift everything up one 
            strandPointer->complementaryStrand[i] = strandPointer->complementaryStrand[i-1];
@@ -160,17 +156,17 @@ void insert_base_subInstruction(struct strand *strandPointer, char base) {
        strandPointer->complementarySize +=1;
        strandPointer->currentBoundPosition +=1;
        //now insert 
-       for(int i = strandPointer->mainSize; i >= strandPointer->currentBoundPosition; i--) {
+       for(int i = strandPointer->mainSize-1; i >= strandPointer->currentBoundPosition-2; i--) {
            //move each element one space up
            strandPointer->mainStrand[i+1] = strandPointer->mainStrand[i];
        }
-/*
+
        if(strandPointer->copyModeFlag == 1) {
-           copy_base_subInstruction(strandPointer, strandPointer->currentBoundPosition-3); 
+           copy_base_subInstruction(strandPointer, strandPointer->currentBoundPosition-2); 
        } else {
-*/
+
            strandPointer->mainStrand[strandPointer->currentBoundPosition-2] = ' '; 
-//       }
+       }
        strandPointer->mainSize += 1; 
    }
 

--- a/src/typogenetics.h
+++ b/src/typogenetics.h
@@ -24,16 +24,18 @@ void mvr_acid(struct strand*);
 void mvl_acid(struct strand*);
 void cop_acid(struct strand*);
 void off_acid(struct strand*);
-void ina_acid(void);
-void inc_acid(void);
-void ing_acid(void);
-void int_acid(void);
+void ina_acid(struct strand*);
+void inc_acid(struct strand*);
+void ing_acid(struct strand*);
+void int_acid(struct strand*);
 void rpy_acid(void);
 void rpu_acid(void);
 void lpu_acid(void);
 void lpy_acid(void);
-
 void call_instructions(int, struct strand*); 
+
+/*--- Sub Instructions ---*/
 void move_subInstruction(struct strand*, int);
-void copy_base_subInstruction(struct strand*); 
+void copy_base_subInstruction(struct strand*, int); 
+void insert_base_subInstruction(struct strand*, char); 
 


### PR DESCRIPTION
insert now working as subcommand used by the GX amino acids 
Updated CopyMode subinstruction to take a location for inserting the copied base to allow copy mode to work with the insert commands 
added a sub_instructions.c file to sub organize the repeated operations in instructions
